### PR TITLE
Run tests for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 matrix:
     include:
+        - python: "2.6"
+          env: TOXENV=py26
         - python: "2.7"
           env: TOXENV=py27
         - python: "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py26,py27,py36,py37
 
 [testenv]
 commands = nosetests -s --with-coverage --cover-package=rcm_nexus --cover-html --cover-html-dir=coverage


### PR DESCRIPTION
It's still used on RHEL 6, let's make sure the code is at least parsable.