### PR TITLE
Move profile configuration to a git repository

### DIFF
--- a/rcm_nexus/command.py
+++ b/rcm_nexus/command.py
@@ -26,10 +26,9 @@ def init():
 
     Next steps:
 
-    - Modify configuration to include each Nexus environment you intend to manage.
+    - Set url to git repository with product configuration.
     - Fine tune each environment's configuration (username, ssl-verify, etc.).
     - Setup passwords (`pass` is a nice tool for this) to match the configured password keys.
-    - Add Nexus staging profiles for each product you intend to manage via Nexus.
     
     For more information on using rcm-nexus (nexus-push, nexus-rollback), see:
 
@@ -38,7 +37,7 @@ def init():
 
 @click.command()
 @click.argument('repo', type=click.Path(exists=True))
-@click.option('--environment', '-e', help='The target Nexus environment (from ~/.config/rcm-nexus/config.yaml)')
+@click.option('--environment', '-e', help='The target Nexus environment (from config file)')
 @click.option('--product', '-p', help='The product key, used to lookup profileId from the configuration')
 @click.option('--version', '-v', help='The product version, used in repository definition metadata')
 @click.option('--ga', '-g', is_flag=True, default=False, help='Push content to the GA group (as opposed to earlyaccess)')
@@ -88,7 +87,7 @@ def push(repo, environment, product, version, ga=False, debug=False):
             sys.exit(1)
 
         print("Promoting repo")
-        promote_profile = nexus_config.get_promote_profile_id(ga)
+        promote_profile = nexus_config.get_promote_profile_id(product, ga)
         staging.promote(session, promote_profile, staging_repo_id, product, version, ga)
 
         if staging.verify_action(session, staging_repo_id, "promote"):
@@ -102,7 +101,7 @@ def push(repo, environment, product, version, ga=False, debug=False):
 
 @click.command()
 @click.argument('staging_repo_name')
-@click.option('--environment', '-e', help='The target Nexus environment (from ~/.config/rcm-nexus/config.yaml)')
+@click.option('--environment', '-e', help='The target Nexus environment (from config file)')
 @click.option('--debug', '-D', is_flag=True, default=False)
 def rollback(staging_repo_name, environment, debug=False):
     """Drop given staging repository.

--- a/rcm_nexus/config.py
+++ b/rcm_nexus/config.py
@@ -27,7 +27,7 @@ class NexusConfig(object):
         self.ssl_verify = data.get(SSL_VERIFY, True)
         self.preemptive_auth = data.get(PREEMPTIVE_AUTH, False)
         self.username = data.get(USERNAME, getpass.getuser())
-        self.password = data.get(PASSWORD, None)
+        self.password = data.get(PASSWORD, "@oracle:ask_password")
         self.interactive = data.get(INTERACTIVE, True)
         self.profile_map = profile_data
         self.ga_promote_profile = data.get(GA_PROMOTE_PROFILE)
@@ -116,13 +116,11 @@ def init_config():
     conf = {
         'prod':{
             URL: 'http://repository.prod.corp.com/nexus',
-            PASSWORD: '@oracle:eval:pass rcm-nexus-prod',
             EA_PROMOTE_PROFILE: "123",
             GA_PROMOTE_PROFILE: "456",
         },
         'stage':{
             URL: 'http://repository.stage.corp.com/nexus',
-            PASSWORD: '@oracle:eval:pass rcm-nexus-stage',
             EA_PROMOTE_PROFILE: "321",
             GA_PROMOTE_PROFILE: "654",
         }

--- a/rcm_nexus/config.py
+++ b/rcm_nexus/config.py
@@ -78,9 +78,12 @@ def load(environment, cli_overrides=None, debug=False):
 
     if debug is True:
         print("Loading main config: %s" % config_path)
-    with open(config_path) as f:
-        dataMap = yaml.safe_load(f)
-        data=dataMap.get(environment)
+    try:
+        with open(config_path) as f:
+            dataMap = yaml.safe_load(f)
+            data = dataMap.get(environment)
+    except IOError as exc:
+        die("Failed to load config file: %s" % exc)
 
     if data is None:
         die("Missing configuration for environment: %s (config file: %s)" % (environment, config_path))
@@ -94,8 +97,11 @@ def load(environment, cli_overrides=None, debug=False):
         print("Loading staging profiles: %s" % profiles)
     profile_data = {}
     if os.path.exists(profiles):
-        with open(profiles) as f:
-            profile_data = yaml.safe_load(f)
+        try:
+            with open(profiles) as f:
+                profile_data = yaml.safe_load(f)
+        except IOError as exc:
+            die("Failed to load config file: %s" % exc)
         if debug is True:
             print("Loaded %d product profiles for: %s" % (len(profile_data.keys()), environment))
     elif debug is True:

--- a/rcm_nexus/config.py
+++ b/rcm_nexus/config.py
@@ -26,7 +26,7 @@ class NexusConfig(object):
         self.url = data[URL]
         self.ssl_verify = data.get(SSL_VERIFY, True)
         self.preemptive_auth = data.get(PREEMPTIVE_AUTH, False)
-        self.username = data.get(USERNAME, None)
+        self.username = data.get(USERNAME, getpass.getuser())
         self.password = data.get(PASSWORD, None)
         self.interactive = data.get(INTERACTIVE, True)
         self.profile_map = profile_data
@@ -112,20 +112,16 @@ def init_config():
     conf_dir = os.path.dirname(conf_path)
     if not os.path.isdir(conf_dir):
         os.makedirs(conf_dir)
-
-    user = os.environ.get('USER') or 'someuser'
     
     conf = {
         'prod':{
             URL: 'http://repository.prod.corp.com/nexus',
-            USERNAME: user,
             PASSWORD: '@oracle:eval:pass rcm-nexus-prod',
             EA_PROMOTE_PROFILE: "123",
             GA_PROMOTE_PROFILE: "456",
         },
         'stage':{
             URL: 'http://repository.stage.corp.com/nexus',
-            USERNAME: user,
             PASSWORD: '@oracle:eval:pass rcm-nexus-stage',
             EA_PROMOTE_PROFILE: "321",
             GA_PROMOTE_PROFILE: "654",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
       "requests",
       "lxml",
       "click",
-      "PyYAML",
       "six",
     ],
     tests_require=test_deps,

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,15 @@ WORDS = ['/usr/share/dict/words', '/usr/dict/words']
 TEST_BASEURL='http://localhost:8080/nexus'
 TEST_INPUT_DIR='test-input'
 
+TEST_CONFIG = {
+    'test': {
+        rcm_nexus.config.URL: TEST_BASEURL,
+        rcm_nexus.config.USERNAME: "jdoe",
+        rcm_nexus.config.PASSWORD: "password",
+    }
+}
+
+
 class NexupBaseTest(unittest.TestCase):
     """
     Creates config files, configures the environment, and cleans up afterwards.
@@ -100,7 +109,7 @@ class NexupBaseTest(unittest.TestCase):
 
         return fpath
 
-    def create_and_load_conf(self, conf={'test':{rcm_nexus.config.URL: TEST_BASEURL}}, profile_data={}):
+    def create_and_load_conf(self, conf=TEST_CONFIG, profile_data={}):
         fpath = self.write_config(conf, profile_data)
         return rcm_nexus.config.load('test')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,16 +4,15 @@ from __future__ import unicode_literals
 from .base import NexupBaseTest
 from unittest import TestCase
 from rcm_nexus import config
-import os
-import yaml
+
+from six.moves import configparser
+
 
 class TestConfigLoad(NexupBaseTest):
 
     def test_init(self):
-        config_file = config.init_config()
-        conf = config.load('prod')
-        self.assertEqual(conf.get_profile_id('MYPRODUCT', is_ga=True) is None, False)
-        self.assertEqual(conf.get_profile_id('MYPRODUCT', is_ga=False) is None, False)
+        config.init_config()
+        self.assertRaises(configparser.NoOptionError, config.load, 'prod')
 
     def test_minimal_from_default(self):
         url='http://nowhere.com/nexus'
@@ -36,11 +35,9 @@ class TestConfigLoad(NexupBaseTest):
         }
 
         profile_map = {
-            'test':{
-                'eap': {
-                    config.GA_PROFILE: str(ga_profile),
-                    config.EA_PROFILE: '9876543210'
-                }
+            'eap': {
+                config.GA_STAGING_PROFILE: str(ga_profile),
+                config.EA_STAGING_PROFILE: '9876543210'
             }
         }
 
@@ -60,11 +57,9 @@ class TestConfigLoad(NexupBaseTest):
         }
 
         profile_map = {
-            'test':{
-                'eap': {
-                    config.GA_PROFILE: '9876543210',
-                    config.EA_PROFILE: str(ea_profile)
-                }
+            'eap': {
+                config.GA_STAGING_PROFILE: '9876543210',
+                config.EA_STAGING_PROFILE: str(ea_profile)
             }
         }
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,9 +4,8 @@ from .base import (TEST_INPUT_DIR, NexupBaseTest)
 import rcm_nexus
 import responses
 import os
-import yaml
-import traceback
 import tempfile
+
 
 class TestRepo(NexupBaseTest):
 

--- a/tests/test_session_delete.py
+++ b/tests/test_session_delete.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from .base import NexupBaseTest
 import rcm_nexus
 import responses
-import os
-import yaml
 import traceback
+
 
 class TestSessionDelete(NexupBaseTest):
 	

--- a/tests/test_session_exists.py
+++ b/tests/test_session_exists.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from .base import NexupBaseTest
 import rcm_nexus
 import responses
-import os
-import yaml
 import traceback
+
 
 class TestSessionExists(NexupBaseTest):
 

--- a/tests/test_session_get.py
+++ b/tests/test_session_get.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from .base import NexupBaseTest
 import rcm_nexus
 import responses
-import os
-import yaml
 import traceback
+
 
 class TestSessionGet(NexupBaseTest):
 	

--- a/tests/test_session_head.py
+++ b/tests/test_session_head.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from .base import NexupBaseTest
 import rcm_nexus
 import responses
-import os
-import yaml
 import traceback
+
 
 class TestSessionHead(NexupBaseTest):
 

--- a/tests/test_session_post.py
+++ b/tests/test_session_post.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from .base import NexupBaseTest
 import rcm_nexus
 import responses
-import os
-import yaml
 import traceback
+
 
 class TestSessionPost(NexupBaseTest):
 	

--- a/tests/test_session_put.py
+++ b/tests/test_session_put.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from .base import NexupBaseTest
 import rcm_nexus
 import responses
-import os
-import yaml
 import traceback
+
 
 class TestSessionPut(NexupBaseTest):
 	

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,10 +1,7 @@
 from .base import (TEST_INPUT_DIR, NexupBaseTest)
 from rcm_nexus import (staging, config, session)
 import responses
-import os
-import yaml
-import traceback
-import tempfile
+
 
 class TestGroup(NexupBaseTest):
 
@@ -13,11 +10,9 @@ class TestGroup(NexupBaseTest):
         ga_profile = '0123456789'
 
         profile_map = {
-            'test':{
-                'eap': {
-                    config.GA_PROFILE: str(ga_profile),
-                    config.EA_PROFILE: '9876543210'
-                }
+            'eap': {
+                config.GA_STAGING_PROFILE: str(ga_profile),
+                config.EA_STAGING_PROFILE: '9876543210'
             }
         }
 
@@ -49,11 +44,9 @@ class TestGroup(NexupBaseTest):
         ga_profile = '0123456789'
 
         profile_map = {
-            'test':{
-                'eap': {
-                    config.GA_PROFILE: str(ga_profile),
-                    config.EA_PROFILE: '9876543210'
-                }
+            'eap': {
+                config.GA_STAGING_PROFILE: str(ga_profile),
+                config.EA_STAGING_PROFILE: '9876543210'
             }
         }
 

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -10,13 +10,7 @@ class TestGroup(NexupBaseTest):
 
     @responses.activate
     def test_start_staging_repo_success(self):
-        url='http://nowhere.com/nexus'
         ga_profile = '0123456789'
-        data={
-            'test': {
-                config.URL: url,
-            }
-        }
 
         profile_map = {
             'test':{
@@ -37,8 +31,7 @@ class TestGroup(NexupBaseTest):
         </promoteResponse>
         """ % expected_repo_id
 
-        rc = self.write_config(data, profile_map)
-        conf = config.load('test')
+        conf = self.create_and_load_conf(profile_data=profile_map)
 
         profile_id = conf.get_profile_id( 'eap', is_ga=True )
         path = staging.STAGE_START_FORMAT.format(profile_id=profile_id)
@@ -53,13 +46,7 @@ class TestGroup(NexupBaseTest):
 
     @responses.activate
     def test_finish_staging_repo_success(self):
-        url='http://nowhere.com/nexus'
         ga_profile = '0123456789'
-        data={
-            'test': {
-                config.URL: url,
-            }
-        }
 
         profile_map = {
             'test':{
@@ -72,8 +59,7 @@ class TestGroup(NexupBaseTest):
 
         repo_id = 'xyz-1001'
 
-        rc = self.write_config(data, profile_map)
-        conf = config.load('test')
+        conf = self.create_and_load_conf(profile_data=profile_map)
 
         profile_id = conf.get_profile_id( 'eap', is_ga=True )
         path = staging.STAGE_FINISH_FORMAT.format(profile_id=profile_id)


### PR DESCRIPTION
This PR changes configuration format from YAML to simpler INI-style understood by `configparser` module. This allows us to drop an extra dependency and also natively supports layering multiple config files.

A big change here is moving the profile identifiers to an external file in a configured git repository. The repo is cloned when the data is needed. An assumption is made that the profile IDs are the same across all environments.

The expected structure of configuration is like this:
* global file in `/etc/xdg/rcm-nexus.conf` – this one would be provided by RPM and contain URLs to production and stage Nexus instance, and URL to a repo with the configuration
* per-user config file in `~/.config/rcm-nexus.conf` – define username and password (or `pass` invocation command)

The defaults are modified to use current username (or value from `$USER` env var) and ask for password interactively. This way the per-user config file is not really needed and it's possible to just install the tool and start using it immediately.