### PR TITLE
Fix repacking

### DIFF
--- a/rcm_nexus/archive.py
+++ b/rcm_nexus/archive.py
@@ -52,6 +52,13 @@ def create_partitioned_zips_from_zip(
     directory and only repackage its contents. If there is no such
     subdirectory, all content will be taken without any changes.
     The top-level directory name does not matter at all.
+
+    Alternatively, the content to be published can be directly under the
+    top-level directory. In such case the top-level directory is dropped and
+    everything else is published.
+
+    If there is more than one top-level entry in the archive, an error is
+    reported.
     """
     zips = Zipper(out_dir, max_count, max_size)
     zf = zipfile.ZipFile(src)
@@ -85,6 +92,9 @@ def create_partitioned_zips_from_zip(
             else:
                 # Not correct location, ignore it.
                 continue
+        else:
+            # Otherwise we only strip the leading component.
+            filename = filename.split("/", 1)[-1]
 
         zips.append(filename, info.file_size, lambda: zf.read(info.filename))
 

--- a/rcm_nexus/archive.py
+++ b/rcm_nexus/archive.py
@@ -65,16 +65,20 @@ def create_partitioned_zips_from_zip(
     repodir = None
 
     zip_objects = zf.infolist()
+    toplevel_objects = set()
 
     # Find if there is a maven-repository subdir under top-level directory.
     for info in zip_objects:
         parts = info.filename.split("/")
+        toplevel_objects.add(parts[0])
         if len(parts) < 3:
             # Not a subdirectory of top-level dir or a file in there.
             continue
         if parts[1] == "maven-repository":
             repodir = os.path.join(*parts[:2]) + "/"
-            break
+
+    if len(toplevel_objects) > 1:
+        raise RuntimeError("Invalid zip file: there are multiple top-level entries.")
 
     # Iterate over all objects in the directory.
     for info in zip_objects:

--- a/rcm_nexus/archive.py
+++ b/rcm_nexus/archive.py
@@ -34,7 +34,7 @@ def create_partitioned_zips_from_dir(
 
 
 def create_partitioned_zips_from_zip(
-    src, out_dir, max_count=MAX_COUNT, max_size=MAX_SIZE
+    src, out_dir, max_count=MAX_COUNT, max_size=MAX_SIZE, debug=False
 ):
     """
     Given a zip archive, split it into smaller chunks and possibly filter out
@@ -96,6 +96,8 @@ def create_partitioned_zips_from_zip(
             # Otherwise we only strip the leading component.
             filename = filename.split("/", 1)[-1]
 
+        if debug:
+            print("Mapping %s -> %s" % (info.filename, filename))
         zips.append(filename, info.file_size, lambda: zf.read(info.filename))
 
     return zips.list()

--- a/rcm_nexus/command.py
+++ b/rcm_nexus/command.py
@@ -66,8 +66,11 @@ def push(repo, environment, product, version, ga=False, debug=False):
         else:
             print("Processing repository zip archive: %s" % repo)
 
-            # Open the zip, walk the entries and normalize the structure to clean zip (if necessary)
-            zip_paths = archive.create_partitioned_zips_from_zip(repo, zips_dir)
+            # Open the zip, walk the entries and normalize the structure to
+            # clean zip
+            zip_paths = archive.create_partitioned_zips_from_zip(
+                repo, zips_dir, debug=debug
+            )
 
         # Open new staging repository with description
         staging_repo_id = staging.start_staging_repo(session, nexus_config, product, version, ga)

--- a/rcm_nexus/command.py
+++ b/rcm_nexus/command.py
@@ -107,6 +107,11 @@ def push(repo, environment, product, version, ga=False, debug=False):
 
             if staging.verify_action(session, promote_entity, "promote"):
                 sys.exit(1)
+    except RuntimeError as exc:
+        if debug:
+            raise
+        print("Error: %s" % exc, file=sys.stderr)
+        sys.exit(1)
     except requests.exceptions.HTTPError as exc:
         if debug:
             raise

--- a/tests/test_archive_zip.py
+++ b/tests/test_archive_zip.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import os
+
 from rcm_nexus import archive
 from .base import NexupBaseTest
 import tempfile
@@ -22,7 +24,7 @@ class ArchiveZipest(NexupBaseTest):
 
         self.assertEqual(
             sorted(info.filename for info in zipfile.ZipFile(zips[0]).infolist()),
-            sorted(paths),
+            sorted(os.path.join(*path.split("/")[1:]) for path in paths),
         )
 
     def test_trim_maven_dir(self):
@@ -59,11 +61,11 @@ class ArchiveZipest(NexupBaseTest):
 
         self.assertEqual(
             sorted(info.filename for info in zipfile.ZipFile(zips[0]).infolist()),
-            paths[:2],
+            sorted(os.path.join(*path.split("/")[1:]) for path in paths[:2]),
         )
         self.assertEqual(
             sorted(info.filename for info in zipfile.ZipFile(zips[1]).infolist()),
-            paths[2:],
+            sorted(os.path.join(*path.split("/")[1:]) for path in paths[2:]),
         )
 
     def test_size_rollover(self):
@@ -84,9 +86,9 @@ class ArchiveZipest(NexupBaseTest):
 
         self.assertEqual(
             sorted(info.filename for info in zipfile.ZipFile(zips[0]).infolist()),
-            paths[:2],
+            sorted(os.path.join(*path.split("/")[1:]) for path in paths[:2]),
         )
         self.assertEqual(
             sorted(info.filename for info in zipfile.ZipFile(zips[1]).infolist()),
-            paths[2:],
+            sorted(os.path.join(*path.split("/")[1:]) for path in paths[2:]),
         )

--- a/tests/test_archive_zip.py
+++ b/tests/test_archive_zip.py
@@ -27,6 +27,22 @@ class ArchiveZipest(NexupBaseTest):
             sorted(os.path.join(*path.split("/")[1:]) for path in paths),
         )
 
+    def test_multiple_top_level_entries(self):
+        self.load_words()
+
+        paths = ["path/one.txt", "another/two.txt"]
+
+        (_f, src_zip) = tempfile.mkstemp(suffix=".zip")
+
+        self.write_zip(src_zip, paths)
+
+        outdir = tempfile.mkdtemp()
+        try:
+            archive.create_partitioned_zips_from_zip(src_zip, outdir)
+            self.fail("RuntimeError not raised")
+        except RuntimeError as exc:
+            self.assertIn("multiple top-level entries", str(exc))
+
     def test_trim_maven_dir(self):
         self.load_words()
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,4 @@ max-line-length = 88
 
 [testenv]
 commands = nosetests --with-coverage --cover-package=rcm_nexus --cover-html --cover-html-dir=coverage
-setenv =
-       XDG_CACHE_HOME={envtmpdir}/
 deps = .[test,ci]


### PR DESCRIPTION
If there is not maven-repository subdirectory, extract everything but remove top level directory.

In debug mode print details about how files are moved.

If the input zip file contains multiple top level entries, an error is reported.