### PR TITLE
Split hostname from username

### DIFF
--- a/rcm_nexus/config.py
+++ b/rcm_nexus/config.py
@@ -167,7 +167,7 @@ def _read_config(path):
 def add_product(config, environment, key, ids):
     tempdir = tempfile.mkdtemp(prefix="rcm-nexus-config-")
     clone_dir = os.path.join(tempdir, "clone")
-    remote_url = config.write_remote_repo.format(user=config.username)
+    remote_url = config.write_remote_repo.format(user=config.username.split("@")[0])
     try:
         print("Cloning remote git configuration repository...")
         _clone_config_repo(clone_dir, remote_url, limit_depth=False)


### PR DESCRIPTION
If the username is an-email address, it's probably not a valid user for whatever service is hosting the configuration. Let's try splitting the hostname part out. This is not guaranteed to always work, but it may help.